### PR TITLE
Seed annotations for all users

### DIFF
--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -129,7 +129,7 @@ class ClassificationStorage(BaseStorage):
     ...
     """
     @transaction.atomic
-    def save(self, user):
+    def save(self, user, additional_users=None):
         saved_labels = {label.text: label for label in self.project.labels.all()}
         for data in self.data:
             docs = self.save_doc(data)
@@ -141,6 +141,9 @@ class ClassificationStorage(BaseStorage):
             saved_labels = self.update_saved_labels(saved_labels, new_labels)
             annotations = self.make_annotations(docs, labels, saved_labels)
             self.save_annotation(annotations, user)
+            if additional_users:
+                for additional_user in additional_users:
+                    self.save_annotation(annotations, additional_user)
 
     @classmethod
     def extract_unique_labels(cls, labels):
@@ -164,7 +167,7 @@ class SequenceLabelingStorage(BaseStorage):
     ...
     """
     @transaction.atomic
-    def save(self, user):
+    def save(self, user, additional_users=None):
         saved_labels = {label.text: label for label in self.project.labels.all()}
         for data in self.data:
             docs = self.save_doc(data)
@@ -176,6 +179,9 @@ class SequenceLabelingStorage(BaseStorage):
             saved_labels = self.update_saved_labels(saved_labels, new_labels)
             annotations = self.make_annotations(docs, labels, saved_labels)
             self.save_annotation(annotations, user)
+            if additional_users:
+                for additional_user in additional_users:
+                    self.save_annotation(annotations, additional_user)
 
     @classmethod
     def extract_unique_labels(cls, labels):

--- a/app/api/views.py
+++ b/app/api/views.py
@@ -280,7 +280,15 @@ class TextUploadAPI(APIView):
         parser = cls.select_parser(file_format)
         data = parser.parse(file)
         storage = project.get_storage(data)
-        storage.save(user)
+
+        if not project.collaborative_annotation:
+            # we don't want to share annotations (each annotator can make their own edits BUT we are also uploading
+            # annotations. So, copy these to each project member so that they can all see the annotations but can choose
+            # to add to it or delete these 'seeded' annotations.
+            additional_users = [project_user for project_user in project.users.all()
+                                if project_user.username != user.username]
+            storage.save(user, additional_users)
+
 
     @classmethod
     def select_parser(cls, file_format):


### PR DESCRIPTION
When importing data with annotations (to seed the annotations), doccano either associates
those annotations with the user who uploaded the data (so annotators cannot see it) or
by selecting "Share annotations across users", all users can see it, but cannot delete the seeded
annotations. This change allows uploaded annotations to be made visible to all project members
but still allows them to independently add/remove to their copy of annotations.